### PR TITLE
Fix Soter errors

### DIFF
--- a/lib/soter.rb
+++ b/lib/soter.rb
@@ -64,8 +64,8 @@ module Soter
     Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}][WP_DB_ID #{::Mongoid.default_client.object_id }]\n reset_database_connections\n")
     Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}][SOT_DB_ID #{@client.object_id }]\n reset_database_connections\n") if @client
     @client.close if @client
-    #@client.reconnect if @client
-    @client = nil
+    @client.reconnect if @client
+
     @queue = nil
     @indexes_created = false
     @database = nil
@@ -119,11 +119,8 @@ module Soter
             else
               config.hosts
             end
-    Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}] CREATING NEW SOTER CLIENT AFTER RESTART?\n")
-    @client = Mongo::Client.new(hosts, config.options)
-    Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}] CREATING NEW SOTER CLIENT AFTER RESTART -> #{@client.object_id}\n")
 
-    @client
+    @client = Mongo::Client.new(hosts, config.options)
   end
 
   def self.queue
@@ -236,7 +233,7 @@ module Soter
     Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}] #{command} FAILED!!!\n\nResetting the database, retry ##{retries}")
     reset_database_connections
     Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}] #{command} FAILED!!!\n\nReady for retry")
-    #retry if retries < 2
+    retry if retries < 2
 
     raise error
   end

--- a/lib/soter.rb
+++ b/lib/soter.rb
@@ -5,10 +5,9 @@ require 'mongo'
 require 'mongo_queue'
 
 module Soter
+  QUEUE_COMMAND_RETRIES_LIMIT = 1
 
   attr_accessor :client
-
-  QUEUE_COMMAND_RETRIES_LIMIT = 1
 
   def self.config
     @config ||= Soter::Config.new

--- a/lib/soter.rb
+++ b/lib/soter.rb
@@ -6,6 +6,8 @@ require 'mongo_queue'
 
 module Soter
 
+  attr_accessor :client
+
   def self.config
     @config ||= Soter::Config.new
   end
@@ -21,7 +23,8 @@ module Soter
       priority:      queue_options.delete(:priority) || 0
     }
 
-    Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}][DB_ID #{::Mongoid.default_client.object_id }]\n enqueue #{job_params.inspect}")
+    Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}][WP_DB_ID #{::Mongoid.default_client.object_id }]\n enqueue #{job_params.inspect}")
+    Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}][SOT_DB_ID #{@client.object_id }]\n enqueue\n") if @client
     job = queue.insert(job)
     dispatch_worker
     return job
@@ -32,7 +35,8 @@ module Soter
   end
 
   def self.reschedule(job_params, active_at)
-    Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}][DB_ID #{::Mongoid.default_client.object_id }]\n reschedule #{job_params.inspect}")
+    Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}][WP_DB_ID #{::Mongoid.default_client.object_id }]\n reschedule #{job_params.inspect}")
+    Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}][SOT_DB_ID #{@client.object_id }]\n reschedule\n") if @client
     queue.modify({ 'job.params' => job_params },
                  { 'active_at'  => active_at  })
     dispatch_worker
@@ -59,7 +63,8 @@ module Soter
   end
 
   def self.reset_database_connections
-    Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}][DB_ID #{::Mongoid.default_client.object_id }]\n reset_database_connections\n")
+    Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}][WP_DB_ID #{::Mongoid.default_client.object_id }]\n reset_database_connections\n")
+    Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}][SOT_DB_ID #{@client.object_id }]\n reset_database_connections\n") if @client
     @client.close if @client
     @queue = nil
     @indexes_created = false
@@ -147,7 +152,8 @@ module Soter
   end
 
   def self.dispatch_worker
-    Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}][DB_ID #{::Mongoid.default_client.object_id }]\n dispatch_worker")
+    Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}][WP_DB_ID #{::Mongoid.default_client.object_id }]\n dispatch_worker\n")
+    Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}][SOT_DB_ID #{@client.object_id }]\n dispatch_worker\n") if @client
     cleanup_workers
 
     throttle_worker_request

--- a/lib/soter.rb
+++ b/lib/soter.rb
@@ -40,6 +40,11 @@ module Soter
     queue.modify({ 'job.params' => job_params },
                  { 'active_at'  => active_at  })
     dispatch_worker
+  rescue => Mongo::Error::SocketError
+    Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}] RESCHEDULE FAILED!!!\n\nResetting the database")
+    reset_database_connections
+    Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}] RESCHEDULE FAILED!!!\n\nReady for retry")
+    retry
   end
 
   def self.update(id, changes={})

--- a/lib/soter.rb
+++ b/lib/soter.rb
@@ -147,7 +147,7 @@ module Soter
   end
 
   def self.dispatch_worker
-    Rails.logger.debug("\n\n[SOTER]\n dispatch_worker #{job_params.inspect}")
+    Rails.logger.debug("\n\n[SOTER]\n dispatch_worker")
     cleanup_workers
 
     throttle_worker_request

--- a/lib/soter.rb
+++ b/lib/soter.rb
@@ -7,6 +7,8 @@ require 'mongo_queue'
 module Soter
   QUEUE_COMMAND_RETRIES_LIMIT = 1
 
+  attr_accessor :client
+
   def self.config
     @config ||= Soter::Config.new
   end

--- a/lib/soter.rb
+++ b/lib/soter.rb
@@ -21,7 +21,7 @@ module Soter
       priority:      queue_options.delete(:priority) || 0
     }
 
-    Rails.logger.debug("\n[SOTER] enqueue\n")
+    Rails.logger.debug("[SOTER] enqueue #{job_params.inspect}")
     job = queue.insert(job)
     dispatch_worker
     return job
@@ -32,7 +32,7 @@ module Soter
   end
 
   def self.reschedule(job_params, active_at)
-    Rails.logger.debug("\n[SOTER] reschedule\n")
+    Rails.logger.debug("[SOTER] reschedule #{job_params.inspect}")
     queue.modify({ 'job.params' => job_params },
                  { 'active_at'  => active_at  })
     dispatch_worker

--- a/lib/soter.rb
+++ b/lib/soter.rb
@@ -40,7 +40,10 @@ module Soter
     queue.modify({ 'job.params' => job_params },
                  { 'active_at'  => active_at  })
     dispatch_worker
-  rescue => Mongo::Error::SocketError
+  rescue Mongo::Error::SocketError => error
+    Rails.logger.debug("\n\n#{error.class}")
+    Rails.logger.debug(error.message)
+    Rails.logger.debug(error.backtrace.join("\n") + "\n\n")
     Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}] RESCHEDULE FAILED!!!\n\nResetting the database")
     reset_database_connections
     Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}] RESCHEDULE FAILED!!!\n\nReady for retry")

--- a/lib/soter.rb
+++ b/lib/soter.rb
@@ -63,7 +63,7 @@ module Soter
   def self.reset_database_connections
     Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}][WP_DB_ID #{::Mongoid.default_client.object_id }]\n reset_database_connections\n")
     Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}][SOT_DB_ID #{@client.object_id }]\n reset_database_connections\n") if @client
-    #@client.close if @client
+    @client.close if @client
     #@client.reconnect if @client
     @client = nil
     @queue = nil

--- a/lib/soter.rb
+++ b/lib/soter.rb
@@ -232,7 +232,7 @@ module Soter
     Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}] #{command} FAILED!!!\n\nResetting the database, retry ##{retries}")
     reset_database_connections
     Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}] #{command} FAILED!!!\n\nReady for retry")
-    retry if retries < 2
+    #retry if retries < 2
 
     raise error
   end

--- a/lib/soter.rb
+++ b/lib/soter.rb
@@ -74,6 +74,7 @@ module Soter
     Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}][WP_DB_ID #{::Mongoid.default_client.object_id }]\n reset_database_connections\n")
     Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}][SOT_DB_ID #{@client.object_id }]\n reset_database_connections\n") if @client
     @client.close if @client
+    @client.reconnect if @client
     @queue = nil
     @indexes_created = false
     @database = nil

--- a/lib/soter.rb
+++ b/lib/soter.rb
@@ -21,6 +21,7 @@ module Soter
       priority:      queue_options.delete(:priority) || 0
     }
 
+    Rails.logger.debug("\n[SOTER] enqueue\n")
     job = queue.insert(job)
     dispatch_worker
     return job
@@ -31,6 +32,7 @@ module Soter
   end
 
   def self.reschedule(job_params, active_at)
+    Rails.logger.debug("\n[SOTER] reschedule\n")
     queue.modify({ 'job.params' => job_params },
                  { 'active_at'  => active_at  })
     dispatch_worker
@@ -57,6 +59,7 @@ module Soter
   end
 
   def self.reset_database_connections
+    Rails.logger.debug("\n[SOTER] reset_database_connections\n")
     @client.close if @client
     @queue = nil
     @indexes_created = false

--- a/lib/soter.rb
+++ b/lib/soter.rb
@@ -119,8 +119,9 @@ module Soter
             else
               config.hosts
             end
-
+    Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}] CREATING NEW SOTER CLIENT AFTER RESTART?\n")
     @client = Mongo::Client.new(hosts, config.options)
+    Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}] CREATING NEW SOTER CLIENT AFTER RESTART -> #{@client.object_id}\n")
   end
 
   def self.queue

--- a/lib/soter.rb
+++ b/lib/soter.rb
@@ -7,8 +7,6 @@ require 'mongo_queue'
 module Soter
   QUEUE_COMMAND_RETRIES_LIMIT = 1
 
-  attr_accessor :client
-
   def self.config
     @config ||= Soter::Config.new
   end

--- a/lib/soter.rb
+++ b/lib/soter.rb
@@ -233,7 +233,7 @@ module Soter
     Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}] #{command} FAILED!!!\n\nResetting the database, retry ##{retries}")
     reset_database_connections
     Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}] #{command} FAILED!!!\n\nReady for retry")
-    retry if retries < 2
+    #retry if retries < 2
 
     raise error
   end

--- a/lib/soter.rb
+++ b/lib/soter.rb
@@ -21,7 +21,7 @@ module Soter
       priority:      queue_options.delete(:priority) || 0
     }
 
-    Rails.logger.debug("[SOTER] enqueue #{job_params.inspect}")
+    Rails.logger.debug("\n\n[SOTER]\n enqueue #{job_params.inspect}")
     job = queue.insert(job)
     dispatch_worker
     return job
@@ -32,7 +32,7 @@ module Soter
   end
 
   def self.reschedule(job_params, active_at)
-    Rails.logger.debug("[SOTER] reschedule #{job_params.inspect}")
+    Rails.logger.debug("\n\n[SOTER]\n reschedule #{job_params.inspect}")
     queue.modify({ 'job.params' => job_params },
                  { 'active_at'  => active_at  })
     dispatch_worker
@@ -59,7 +59,7 @@ module Soter
   end
 
   def self.reset_database_connections
-    Rails.logger.debug("\n[SOTER] reset_database_connections\n")
+    Rails.logger.debug("\n\n[SOTER]\n reset_database_connections\n")
     @client.close if @client
     @queue = nil
     @indexes_created = false
@@ -147,6 +147,7 @@ module Soter
   end
 
   def self.dispatch_worker
+    Rails.logger.debug("\n\n[SOTER]\n dispatch_worker #{job_params.inspect}")
     cleanup_workers
 
     throttle_worker_request

--- a/lib/soter.rb
+++ b/lib/soter.rb
@@ -34,10 +34,32 @@ module Soter
     queue.remove({ 'job.params' => job_params })
   end
 
+  # def self.reschedule(job_params, active_at)
+  #   retries ||= 0
+  #   Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}][WP_DB_ID #{::Mongoid.default_client.object_id }]\n reschedule #{job_params.inspect}")
+  #   Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}][SOT_DB_ID #{@client.object_id }]\n reschedule\n") if @client
+  #   queue.modify({ 'job.params' => job_params },
+  #                { 'active_at'  => active_at  })
+  #   dispatch_worker
+  # rescue Mongo::Error::SocketError => error
+  #   retries += 1
+  #   Rails.logger.debug("\n\n#{error.class}")
+  #   Rails.logger.debug(error.message)
+  #   Rails.logger.debug(error.backtrace.join("\n") + "\n\n")
+  #   Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}] RESCHEDULE FAILED!!!\n\nResetting the database, retry ##{retries}")
+  #   reset_database_connections
+  #   Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}] RESCHEDULE FAILED!!!\n\nReady for retry")
+  #   retry
+  # end
+  # v2
   def self.reschedule(job_params, active_at)
     retries ||= 0
     Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}][WP_DB_ID #{::Mongoid.default_client.object_id }]\n reschedule #{job_params.inspect}")
     Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}][SOT_DB_ID #{@client.object_id }]\n reschedule\n") if @client
+    unless @client.cluster.connected?
+      Rails.logger.debug("\n\n********\n\n********\n CLUSTER WASN'T CONNECTED!\n Triggering reconnection\n\n********\n\n********\n\n\n********\n\n********\n")
+      reset_database_connections
+    end
     queue.modify({ 'job.params' => job_params },
                  { 'active_at'  => active_at  })
     dispatch_worker
@@ -46,9 +68,9 @@ module Soter
     Rails.logger.debug("\n\n#{error.class}")
     Rails.logger.debug(error.message)
     Rails.logger.debug(error.backtrace.join("\n") + "\n\n")
-    Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}] RESCHEDULE FAILED!!!\n\nResetting the database, retry ##{retries}")
+    Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}] CATASTROPHIC ERRROR RESCHEDULE FAILED!!!\n\nResetting the database, retry ##{retries}")
     reset_database_connections
-    Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}] RESCHEDULE FAILED!!!\n\nReady for retry")
+    Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}] CATASTROPHIC ERRROR RESCHEDULE FAILED!!!\n\nReady for retry")
     retry
   end
 

--- a/lib/soter.rb
+++ b/lib/soter.rb
@@ -21,7 +21,7 @@ module Soter
       priority:      queue_options.delete(:priority) || 0
     }
 
-    Rails.logger.debug("\n\n[SOTER]\n enqueue #{job_params.inspect}")
+    Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}][DB_ID #{::Mongoid.default_client.object_id }]\n enqueue #{job_params.inspect}")
     job = queue.insert(job)
     dispatch_worker
     return job
@@ -32,7 +32,7 @@ module Soter
   end
 
   def self.reschedule(job_params, active_at)
-    Rails.logger.debug("\n\n[SOTER]\n reschedule #{job_params.inspect}")
+    Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}][DB_ID #{::Mongoid.default_client.object_id }]\n reschedule #{job_params.inspect}")
     queue.modify({ 'job.params' => job_params },
                  { 'active_at'  => active_at  })
     dispatch_worker
@@ -59,7 +59,7 @@ module Soter
   end
 
   def self.reset_database_connections
-    Rails.logger.debug("\n\n[SOTER]\n reset_database_connections\n")
+    Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}][DB_ID #{::Mongoid.default_client.object_id }]\n reset_database_connections\n")
     @client.close if @client
     @queue = nil
     @indexes_created = false
@@ -147,7 +147,7 @@ module Soter
   end
 
   def self.dispatch_worker
-    Rails.logger.debug("\n\n[SOTER]\n dispatch_worker")
+    Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}][DB_ID #{::Mongoid.default_client.object_id }]\n dispatch_worker")
     cleanup_workers
 
     throttle_worker_request

--- a/lib/soter.rb
+++ b/lib/soter.rb
@@ -233,7 +233,7 @@ module Soter
     Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}] #{command} FAILED!!!\n\nResetting the database, retry ##{retries}")
     reset_database_connections
     Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}] #{command} FAILED!!!\n\nReady for retry")
-    #retry if retries < 2
+    retry if retries < 2
 
     raise error
   end

--- a/lib/soter.rb
+++ b/lib/soter.rb
@@ -63,8 +63,9 @@ module Soter
   def self.reset_database_connections
     Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}][WP_DB_ID #{::Mongoid.default_client.object_id }]\n reset_database_connections\n")
     Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}][SOT_DB_ID #{@client.object_id }]\n reset_database_connections\n") if @client
-    @client.close if @client
-    @client.reconnect if @client
+    #@client.close if @client
+    #@client.reconnect if @client
+    @client = nil
     @queue = nil
     @indexes_created = false
     @database = nil

--- a/lib/soter.rb
+++ b/lib/soter.rb
@@ -122,6 +122,8 @@ module Soter
     Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}] CREATING NEW SOTER CLIENT AFTER RESTART?\n")
     @client = Mongo::Client.new(hosts, config.options)
     Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}] CREATING NEW SOTER CLIENT AFTER RESTART -> #{@client.object_id}\n")
+
+    @client
   end
 
   def self.queue

--- a/lib/soter.rb
+++ b/lib/soter.rb
@@ -35,7 +35,7 @@ module Soter
   end
 
   def self.reschedule(job_params, active_at)
-    retries || = 0
+    retries ||= 0
     Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}][WP_DB_ID #{::Mongoid.default_client.object_id }]\n reschedule #{job_params.inspect}")
     Rails.logger.debug("\n\n[SOTER][PID #{Process.pid}][SOT_DB_ID #{@client.object_id }]\n reschedule\n") if @client
     queue.modify({ 'job.params' => job_params },

--- a/lib/soter/job_worker.rb
+++ b/lib/soter/job_worker.rb
@@ -148,7 +148,7 @@ module Soter
     end
 
     def log(message)
-      @log << "[#{worker_id}][#{Time.now.iso8601}] " + message + "\n"
+      @log << "[PID #{Process.pid}][#{worker_id}][#{Time.now.iso8601}] " + message + "\n"
     end
 
     def queue_misses_limit

--- a/lib/soter/job_worker.rb
+++ b/lib/soter/job_worker.rb
@@ -17,11 +17,11 @@ module Soter
       schrodingers_fork do
         Soter.job_worker(true)
         touch_worker_file
-        Rails.logger.debug("\n\n[SOTER_WORKER]\n worker#start")
+        Rails.logger.debug("\n\n[SOTER_WORKER][PID #{Process.pid}][DB_ID #{::Mongoid.default_client.object_id }]\n worker#start")
         Soter.reset_database_connections if fork?
 
         @callbacks[:worker_start].each  { |callback| callback.call(fork?) }
-        Rails.logger.debug("\n\n[SOTER_WORKER]\n worker#perform")
+        Rails.logger.debug("\n\n[SOTER_WORKER][PID #{Process.pid}][DB_ID #{::Mongoid.default_client.object_id }]\n worker#perform")
         perform
         @callbacks[:worker_finish].each { |callback| callback.call(fork?) }
 
@@ -33,12 +33,12 @@ module Soter
     private
 
     def schrodingers_fork
-      Rails.logger.debug("\n\n[SOTER_WORKER]\n schrodingers_fork...")
+      Rails.logger.debug("\n\n[SOTER_WORKER][PID #{Process.pid}][DB_ID #{::Mongoid.default_client.object_id }]\n schrodingers_fork...")
       if fork?
-        Rails.logger.debug("\n\n[SOTER_WORKER]\n fork enabled")
+        Rails.logger.debug("\n\n[SOTER_WORKER][PID #{Process.pid}][DB_ID #{::Mongoid.default_client.object_id }]\n fork enabled")
 
         process_id = fork { yield; exit }
-        Rails.logger.debug("\n\n[SOTER_WORKER]\n PID for proccess: #{process_id}")
+        Rails.logger.debug("\n\n[SOTER_WORKER][PID #{Process.pid}][DB_ID #{::Mongoid.default_client.object_id }]\n PID for proccess: #{process_id}")
         Process.detach(process_id)
       else
         yield

--- a/lib/soter/job_worker.rb
+++ b/lib/soter/job_worker.rb
@@ -17,9 +17,11 @@ module Soter
       schrodingers_fork do
         Soter.job_worker(true)
         touch_worker_file
+        Rails.logger.debug("\n[SOTER] worker#start")
         Soter.reset_database_connections if fork?
 
         @callbacks[:worker_start].each  { |callback| callback.call(fork?) }
+        Rails.logger.debug("\n[SOTER] worker#perform")
         perform
         @callbacks[:worker_finish].each { |callback| callback.call(fork?) }
 
@@ -31,12 +33,12 @@ module Soter
     private
 
     def schrodingers_fork
-      Rails.logger.debug("\n\n[SOTER] schrodingers_fork...")
+      Rails.logger.debug("[SOTER] schrodingers_fork...")
       if fork?
-        Rails.logger.debug("\n\n[SOTER] fork enabled")
+        Rails.logger.debug("[SOTER] fork enabled")
 
         process_id = fork { yield; exit }
-        Rails.logger.debug("\n[SOTER] PID for proccess: #{process_id}\n\n")
+        Rails.logger.debug("\n[SOTER] PID for proccess: #{process_id}")
         Process.detach(process_id)
       else
         yield

--- a/lib/soter/job_worker.rb
+++ b/lib/soter/job_worker.rb
@@ -17,11 +17,11 @@ module Soter
       schrodingers_fork do
         Soter.job_worker(true)
         touch_worker_file
-        Rails.logger.debug("\n[SOTER] worker#start")
+        Rails.logger.debug("\n\n[SOTER_WORKER]\n worker#start")
         Soter.reset_database_connections if fork?
 
         @callbacks[:worker_start].each  { |callback| callback.call(fork?) }
-        Rails.logger.debug("\n[SOTER] worker#perform")
+        Rails.logger.debug("\n\n[SOTER_WORKER]\n worker#perform")
         perform
         @callbacks[:worker_finish].each { |callback| callback.call(fork?) }
 
@@ -33,12 +33,12 @@ module Soter
     private
 
     def schrodingers_fork
-      Rails.logger.debug("[SOTER] schrodingers_fork...")
+      Rails.logger.debug("\n\n[SOTER_WORKER]\n schrodingers_fork...")
       if fork?
-        Rails.logger.debug("[SOTER] fork enabled")
+        Rails.logger.debug("\n\n[SOTER_WORKER]\n fork enabled")
 
         process_id = fork { yield; exit }
-        Rails.logger.debug("\n[SOTER] PID for proccess: #{process_id}")
+        Rails.logger.debug("\n\n[SOTER_WORKER]\n PID for proccess: #{process_id}")
         Process.detach(process_id)
       else
         yield

--- a/lib/soter/job_worker.rb
+++ b/lib/soter/job_worker.rb
@@ -16,11 +16,13 @@ module Soter
     def start
       schrodingers_fork do
         Soter.job_worker(true)
+        @callbacks[:worker_start].each  { |callback| callback.call(fork?) }
+
         touch_worker_file
         Rails.logger.debug("\n\n[SOTER_WORKER][PID #{Process.pid}][DB_ID #{::Mongoid.default_client.object_id }]\n worker#start")
         Soter.reset_database_connections if fork?
 
-        @callbacks[:worker_start].each  { |callback| callback.call(fork?) }
+        #@callbacks[:worker_start].each  { |callback| callback.call(fork?) }
         Rails.logger.debug("\n\n[SOTER_WORKER][PID #{Process.pid}][DB_ID #{::Mongoid.default_client.object_id }]\n worker#perform")
         perform
         @callbacks[:worker_finish].each { |callback| callback.call(fork?) }

--- a/lib/soter/job_worker.rb
+++ b/lib/soter/job_worker.rb
@@ -22,8 +22,6 @@ module Soter
 
         Soter.reset_database_connections if fork?
 
-        #@callbacks[:worker_start].each  { |callback| callback.call(fork?) }
-
         perform
         @callbacks[:worker_finish].each { |callback| callback.call(fork?) }
 
@@ -146,7 +144,7 @@ module Soter
     end
 
     def log(message)
-      @log << "[PID #{Process.pid}][#{worker_id}][#{Time.now.iso8601}] " + message + "\n"
+      @log << "[#{worker_id}][#{Time.now.iso8601}] " + message + "\n"
     end
 
     def queue_misses_limit

--- a/lib/soter/job_worker.rb
+++ b/lib/soter/job_worker.rb
@@ -31,8 +31,12 @@ module Soter
     private
 
     def schrodingers_fork
+      Rails.logger.debug("\n\n[SOTER] schrodingers_fork...")
       if fork?
+        Rails.logger.debug("\n\n[SOTER] fork enabled")
+
         process_id = fork { yield; exit }
+        Rails.logger.debug("\n[SOTER] PID for proccess: #{process_id}\n\n")
         Process.detach(process_id)
       else
         yield

--- a/lib/soter/job_worker.rb
+++ b/lib/soter/job_worker.rb
@@ -19,11 +19,11 @@ module Soter
         @callbacks[:worker_start].each  { |callback| callback.call(fork?) }
 
         touch_worker_file
-        Rails.logger.debug("\n\n[SOTER_WORKER][PID #{Process.pid}][DB_ID #{::Mongoid.default_client.object_id }]\n worker#start")
+
         Soter.reset_database_connections if fork?
 
         #@callbacks[:worker_start].each  { |callback| callback.call(fork?) }
-        Rails.logger.debug("\n\n[SOTER_WORKER][PID #{Process.pid}][DB_ID #{::Mongoid.default_client.object_id }]\n worker#perform")
+
         perform
         @callbacks[:worker_finish].each { |callback| callback.call(fork?) }
 
@@ -35,12 +35,8 @@ module Soter
     private
 
     def schrodingers_fork
-      Rails.logger.debug("\n\n[SOTER_WORKER][PID #{Process.pid}][DB_ID #{::Mongoid.default_client.object_id }]\n schrodingers_fork...")
       if fork?
-        Rails.logger.debug("\n\n[SOTER_WORKER][PID #{Process.pid}][DB_ID #{::Mongoid.default_client.object_id }]\n fork enabled")
-
         process_id = fork { yield; exit }
-        Rails.logger.debug("\n\n[SOTER_WORKER][PID #{Process.pid}][DB_ID #{::Mongoid.default_client.object_id }]\n PID for proccess: #{process_id}")
         Process.detach(process_id)
       else
         yield


### PR DESCRIPTION
Fixes:
* https://jira.outmatch.com/browse/VT-801
* https://jira.outmatch.com/browse/VT-811

Changes overview:
* Wrap any interaction with the Mongo::Queue instance in a retry block that will guard against SocketErrors. This isn't an ideal solution since it's only treating the symptom and not fixing the root cause, however, taking time to research and fix this properly will be pretty time consuming, and seems to be related to the mongo gem itself. See https://github.com/mongodb/mongo-ruby-driver/pull/1918

* Move the worker_start callback at the beginning of the start yield block so the database connection reset happens ASAP.

Reviewers:
@suckak @rplancarte 